### PR TITLE
Removed backslash

### DIFF
--- a/doc_source/connect-lambda-functions.md
+++ b/doc_source/connect-lambda-functions.md
@@ -29,7 +29,7 @@ Use the following [add\-permission](http://docs.aws.amazon.com/cli/latest/refere
 ```
 aws lambda add-permission --function-name function:my-lambda-function --statement-id 1 \
 --principal connect.amazonaws.com  --action lambda:InvokeFunction --source-account 123456789012 \
---source-arn arn:aws:connect:us-east-1:123456789012:instance/def1a4fc-ac9d-11e6-b582-06a0be38cccf \
+--source-arn arn:aws:connect:us-east-1:123456789012:instance/def1a4fc-ac9d-11e6-b582-06a0be38cccf
 ```
 
 This command uses the following input:


### PR DESCRIPTION
The last backslash is not needed and create confusion since the command won't "work".

*Issue #, if available:*

Command won't execute

*Description of changes:*

With the backslash at the end the command won't execute, by removing it the problem goes away.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
