### PR TITLE
Fix Python syntax in sample Lambda snippet

### DIFF
--- a/doc_source/connect-lambda-functions.md
+++ b/doc_source/connect-lambda-functions.md
@@ -120,8 +120,8 @@ And this example shows an example response using Python:
 
 ```
 def lambda_handler(event, context):
-resultMap = {"Name":"CustomerName","Address":"1234 Main Road","CallerType":"Patient"};
-return resultMap;
+    resultMap = {"Name":"CustomerName","Address":"1234 Main Road","CallerType":"Patient"}
+    return resultMap
 ```
 
 The output returned from the function must be a flat object of key/value pairs, with values that include only alphanumeric, dash, and underscore characters\. Nested and complex objects are not supported\. The size of the returned data must be less than 32 Kb of UTF\-8 data\.


### PR DESCRIPTION
Applied missing indentation and removed unnecessary semicolons.

*Issue #, if available:*
N/A

*Description of changes:*
See commit message.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
