### PR TITLE
Clarify 'Abandoned' Metric

### DIFF
--- a/doc_source/real-time-metrics-reports.md
+++ b/doc_source/real-time-metrics-reports.md
@@ -66,7 +66,7 @@ You can download the data included in your report as a comma\-separated value \(
 The following metrics are available to include in real\-time metrics reports in Amazon Connect\. The metrics available to include in a report depend on the report type\.
 
 **Abandoned**  <a name="abandoned-real-time"></a>
-Count of contacts disconnected by the customer while in the queue during the specified time range\. Contacts queued for callback are not counted as abandoned\.
+Count of contacts disconnected by the customer while in the queue during the specified time range\. This metric can only be grouped by Queue or Phone Number groupings. Contacts queued for callback are not counted as abandoned\.
 
 **Active**  <a name="active-real-time"></a>
 Indicates whether the agent is currently active on a contact\. The value is 1 \(true\) or 0 \(false\)\.


### PR DESCRIPTION
*Description of changes:*
Clarify that 'Abandoned' metric can only be grouped by Queue or Phone number groupings.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
