### PR TITLE
Updated reference on how to reference attributes

### DIFF
--- a/doc_source/how-to-reference-attributes.md
+++ b/doc_source/how-to-reference-attributes.md
@@ -56,9 +56,13 @@ Use a **Play prompt** block to use an audio file to play as a greeting or messag
 
 Hello $\.External\.FirstName $\.External\.LastName, thank you for calling\.
 
-Alternatively, you could store the attributes returned from the Lambda function using a **Set contact attributes** block, and then reference the user\-defined attribute created in the text to speech string\.
+Alternatively, you could store the attributes returned from the Lambda function using a **Set contact attributes** block, and then reference the user\-defined attribute created in the text to speech string\. 
 
 ![\[Image NOT FOUND\]](http://docs.aws.amazon.com/connect/latest/adminguide/images/play-prompt-attribute.png)
+
+**NOTE:** If you are referencing a user-defined attribute that was previously set as a contact attribute in the contact flow / via the API, you can reference the attribute using the $\.Attributes\.nameOfAttribute syntax. For example, if the contact in question has attributes "FirstName" and "LastName" set previously, reference them as follows:
+
+Hello $\.Attributes\.FirstName $\.Attributes\.LastName, thank you for calling\.
 
 ## Getting Customer Input Using an Amazon Lex Bot<a name="attribs-cust-input-lex-bot"></a>
 


### PR DESCRIPTION
Added $.Attributes syntax for contact attributes, which was missing

*Issue #, if available:* $.Attribute syntax was not mentioned for referencing contact attributes that are not pulled from Lambda

*Description of changes:* Added documentation to indicate you can use $.Attributes.nameOfAttribute for this purpose


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
