### PR TITLE
Update start-media-streaming.md configuration tip

### DIFF
--- a/doc_source/start-media-streaming.md
+++ b/doc_source/start-media-streaming.md
@@ -24,6 +24,7 @@ Captures what the customer hears and says during a contact\. You can then perfor
 
 ## Configuration tips<a name="start-media-streaming-tips"></a>
 + You must enable live media streaming in your instance to successfully capture customer audio\. For instructions, see [Capture customer audio: live media streaming](customer-voice-streams.md)\.
++ When selecting the stream to start, only choose one option. Selecting both options will result in an inaudible media stream.
 + Customer audio is captured until a **Stop media streaming** block is invoked, even if the contact is passed to another contact flow\.
 + You must use a **Stop media streaming** block to stop media streaming\.
 + If this block is triggered during a chat conversation, the contact is routed down the **Error** branch\.


### PR DESCRIPTION
By default, when a new Start media streaming block is added it has both From the customer and To the customer options selected. I added a configuration tip to only select one of the two options as having both selected will result in a choppy and inaudible media stream.

*Issue #, if available:*

*Description of changes:*
Added line: + When selecting the stream to start, only choose one option. Selecting both options will result in an inaudible media stream.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
