### PR TITLE
Update flow-language-example.md

### DIFF
--- a/doc_source/flow-language-example.md
+++ b/doc_source/flow-language-example.md
@@ -43,11 +43,7 @@ To learn how to get block identifiers, we recommend creating a new contact flow 
                 "Conditions": []
             },
             "Parameters": {
-                "Prompt": {
-                    "Text": "Thanks for calling the sample flow!",
-                    "TextType": "text",
-                    "PromptId": null
-                }
+                "Text": "Thanks for calling the sample flow!"
             }
         },
         {


### PR DESCRIPTION
The following example does not match the current specification, MessageParticipant params does not have a Prompt child

Removed the Prompt child object and invalid TextType attribute


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
