### PR TITLE
Rename `Apply` -> `Save` for button text

### DIFF
--- a/doc_source/contact-flow-logs.md
+++ b/doc_source/contact-flow-logs.md
@@ -1,25 +1,22 @@
 # Enable contact flow logs<a name="contact-flow-logs"></a>
 
-**Tip**  
+**Tip**
 Amazon Connect delivers contact flow logs at least once\. They may be delivered again for multiple reasons\. For example, a service retry due to an unavoidable failure\.
 
 ## Step 1: Enable logging for your instance<a name="enable-contact-flow-logs"></a>
 
-By default when you create a new Amazon Connect instance, an Amazon CloudWatch log group is created automatically to store the logs for your instance\. 
+By default when you create a new Amazon Connect instance, an Amazon CloudWatch log group is created automatically to store the logs for your instance\.
 
 Use the following procedure to check that logging is enabled for your instance\.
 
 1. Open the Amazon Connect console\.
-
 1. Choose the instance alias for your instance\.
-
 1. Choose **Contact flows**\.
-
-1. Scroll to bottom of the page\. Select **Enable Contact flow logs** and choose **Apply**\.
+1. Scroll to bottom of the page\. Select **Enable Contact flow logs** and click **Save**\.
 
 ## Step 2: Add the Set logging behavior block<a name="use-set-logging-behavior-block"></a>
 
-Logs are generated only for contact flows that include a [Set logging behavior](set-logging-behavior.md) block with logging set to enabled\. 
+Logs are generated only for contact flows that include a [Set logging behavior](set-logging-behavior.md) block with logging set to enabled\.
 
 You control which flows, or parts of flows, logs are generated for by including multiple **Set logging behavior** blocks and configuring them as needed\.
 
@@ -28,9 +25,6 @@ When you use a **Set logging behavior** block to enable or disable logging for a
 **To enable or disable contact flow logs for a contact flow**
 
 1. Add a [Set logging behavior](set-logging-behavior.md) block and connect it to another block in the flow\.
-
 1. Open the properties for the block\. Choose **Enable** or **Disable**\.
-
 1. Choose **Save**\.
-
 1. If you add a **Set logging behavior** block to a contact flow that is already published, you must publish it again to start generating logs for it\.


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

- UI change no longer matches documentation; `Apply` button is now `Save`.
- Also of concern, currently there are changes in this repository that aren't reflected on https://docs.aws.amazon.com/connect/latest/adminguide/contact-flow-logs.html#enable-contact-flow-logs (such as `Choose Flows` should be `Choose Contact flows` - went to fix this, but already in this repository, just not live in the docs. Is there a publishing issue?

Finally, not sure why all the escaping of full stops/dashes in these markdowns - don't see this in other AWS documentation repositories?

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
