### PR TITLE
Fixed timeout parameter

### DIFF
--- a/doc_source/participant-actions-getparticipantinput.md
+++ b/doc_source/participant-actions-getparticipantinput.md
@@ -14,7 +14,7 @@ Gathers customer input \(a DTMF collection for voice contacts, or an entered str
         "SourceType": The source from which the message will be fetched. The only supported type is S3
         "MediaType": The type of the message to be played. The only supported type is Audio
     }
-    "InputTimeoutSeconds": The number of seconds to wait for input to be collected before proceeding with a timeout error. For the Voice channel this is the timeout until the *first* DTMF digit is entered. Must be defined statically, and must be a valid integer larger than zero.
+    "InputTimeLimitSeconds": The number of seconds to wait for input to be collected before proceeding with a timeout error. For the Voice channel this is the timeout until the *first* DTMF digit is entered. Must be defined statically, and must be a valid integer larger than zero.
     "StoreInput": "True" or "False". Must be statically defined.
     "InputValidation": { An object that defines how to validate customer inputs, required if and only if StoreInput is True
         "PhoneNumberValidation": { Optional, one of the ways to validate inputs, make sure that it's a valid phone number. May not be specified if CustomValidation is specified.

--- a/doc_source/participant-actions-transferparticipanttothirdparty.md
+++ b/doc_source/participant-actions-transferparticipanttothirdparty.md
@@ -7,7 +7,7 @@ Transfers the participant to a specified phone number\. Optionally continues flo
 ```
 {
     "ThirdPartyPhoneNumber": A phone number, in e.164 format, of the external number to which to transfer the contact. May be defined statically or dynamically. 
-    "ThirdPartyConnectionTimeoutSeconds": An integer, between 0 and 600 (inclusive) representing the number of seconds to wait for the third party to answer before canceling the third party call. Only used if ContinueFlowExecution is not False. Must be defined fully statically or as a single valid JSONPath identifier.
+    "ThirdPartyConnectionTimeLimitSeconds": An integer, between 0 and 600 (inclusive) representing the number of seconds to wait for the third party to answer before canceling the third party call. Only used if ContinueFlowExecution is not False. Must be defined fully statically or as a single valid JSONPath identifier.
     "ContinueFlowExecution": "True" or "False". If not defined or True, the flow continues running after the third party call finishes, if False the flow does not continue, as long as the phone call to the third party succeeds. Must be defined statically. 
     "ThirdPartyDTMFDigits": An optional series of DTMF digits to send to the third party when the call succeeds. Must be defined fully statically or as a single valid JSONPath identifier. Must be 50 or fewer characters chosen from numeric digits, comma, asterisk, and pound sign
     "CallerId": { Optional, an override of the caller ID to present when dialing the third party


### PR DESCRIPTION
*Description of changes:*

Changed `ThirdPartyConnectionTimeoutSeconds` parameter name to actual `ThirdPartyConnectionTimeLimitSeconds`.

This is the output from describe contact flow content for this block:

```json
{
  "Identifier": "750f976d-d852-4f95-bb66-75b46de3aab1",
  "Parameters": {
    "ThirdPartyPhoneNumber": "+15555555555",
    "ThirdPartyConnectionTimeLimitSeconds": "30",
    "ContinueFlowExecution": "False"
  },
  "Transitions": {
    "NextAction": "a5ae9e56-d129-42ce-9bf2-54ee799bfb07",
    "Errors": [
      {
        "NextAction": "a5ae9e56-d129-42ce-9bf2-54ee799bfb07",
        "ErrorType": "NoMatchingError"
      }
    ],
    "Conditions": []
  },
  "Type": "TransferParticipantToThirdParty"
}
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
