### PR TITLE
Update set-working-queue.md

### DIFF
--- a/doc_source/set-working-queue.md
+++ b/doc_source/set-working-queue.md
@@ -27,7 +27,7 @@ You can use this block in the following [contact flow types](create-contact-flow
 ![\[Image NOT FOUND\]](http://docs.aws.amazon.com/connect/latest/adminguide/images/set-working-queue-properties.png)
 
 Note the following properties:
-+ **By queue > Set dynamically**\. To set the queue dynamically, you must specify the Amazon Resource Name \(ARN\) or ID for the queue rather than the queue name\. To find the ID or ARN for a queue, open **Routing, Queues** in the navigation menu and choose the desired queue. The ARN can be found by expanding **Show additional queue information**. The queue ID is a subset of the ARN and consists of the characters following  `/queue`. For example, `.../queue/aaaaaaaa-bbbb-cccc-dddd-111111111111`\.
++ **By queue > Set dynamically**\. To set the queue dynamically, you must specify the Amazon Resource Name \(ARN\) or ID for the queue rather than the queue name\. To find the ID or ARN for a queue, open **Routing, Queues** in the navigation menu and choose the desired queue. The ARN can be found by expanding **Show additional queue information**. The queue ID is a subset of the ARN and consists of the characters following  `/queue/`. For example, `.../queue/aaaaaaaa-bbbb-cccc-dddd-111111111111`\.
 
 ## Configured block<a name="set-working-queue-configured"></a>
 

--- a/doc_source/set-working-queue.md
+++ b/doc_source/set-working-queue.md
@@ -27,7 +27,7 @@ You can use this block in the following [contact flow types](create-contact-flow
 ![\[Image NOT FOUND\]](http://docs.aws.amazon.com/connect/latest/adminguide/images/set-working-queue-properties.png)
 
 Note the following properties:
-+ **By queue > Set dynamically**\. To set the queue dynamically, you must specify the Amazon Resource Name \(ARN\) for the queue rather than the queue name\. To find the ARN for a queue, open the queue in the queue editor\. The ARN is included as the last part of the URL displayed in the browser address bar after /queue\. For example, `.../queue/aaaaaaaa-bbbb-cccc-dddd-111111111111`\.
++ **By queue > Set dynamically**\. To set the queue dynamically, you must specify the Amazon Resource Name \(ARN\) or ID for the queue rather than the queue name\. To find the ID or ARN for a queue, open **Routing, Queues** in the navigation menu and choose the desired queue. The ARN can be found by expanding **Show additional queue information**. The queue ID is a subset of the ARN and consists of the characters following  `/queue`. For example, `.../queue/aaaaaaaa-bbbb-cccc-dddd-111111111111`\.
 
 ## Configured block<a name="set-working-queue-configured"></a>
 


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
The **Set working queue block** within Amazon Connect now supports entering either a queue's ARN or its ID, not just its ARN. In addition, a queue's ID (erroneously referred to as the queue's ARN in the previous documentation) can no longer be found in the address bar as described.

My changes inform the reader that either the queue ID or ARN can be used in the **Set working queue block** and that each can be found by expanding **Show additional queue information** on the queue's page.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
